### PR TITLE
translate-cli usability improvements and PomodoBar app development start

### DIFF
--- a/log.md
+++ b/log.md
@@ -1111,3 +1111,30 @@ java の学習のため、環境構築（vscode + java）
 - translate-cli
   - [repository](https://github.com/HasutoSasaki/translate-cli)
   - [commit](https://github.com/HasutoSasaki/translate-cli/commits/master/?since=2025-06-23&until=2025-06-23)
+
+### Day 54: June 24, Tuesday
+
+**Today's Progress**:
+
+- translate-cli
+  - text の指定をフラグではなく、引数で指定できるように修正
+  - 不要なファイルを削除し、リファクタリングを行った
+- pomodoBar
+  - electron でバーにポモドーロタイマーを表示するアプリを作成中
+  - バーに表示するやり方がわからない。ので、引き続き作業
+
+**Thoughts**:
+
+- より使いやすさを求めて、フラグが不要と感じ、削除したら、より良くなった。
+- translate-cli のリファクタリングは、コードの可読性を向上させるために必要な作業だった。
+- electron でのアプリ開発を copilot に頼りすぎたため、改で自分で一から作ることにした
+
+**Link(s) to work**:
+
+- translate-cli
+  - [repository](https://github.com/HasutoSasaki/translate-cli)
+  - [commit](https://github.com/HasutoSasaki/translate-cli/commits/master/?since=2025-06-24&until=2025-06-24)
+- PomodoBar
+  - [repository](https://github.com/HasutoSasaki/PomodoBar)
+  - [commit](https://github.com/HasutoSasaki/PomodoBar/commits/master/?since=2025-06-24&until=2025-06-24)
+    ※まだ、整理できていないのでコミットはありません。


### PR DESCRIPTION
## Summary
This PR includes translate-cliの使い勝手向上のための改修と、新規ElectronアプリPomodoBarの開発開始:
1. translate-cliでテキスト指定方法をフラグから引数に変更し、不要ファイル削除・リファクタリングを実施
2. Electron製ポモドーロタイマーアプリ「PomodoBar」の開発を開始

## Changes Made

### translate-cli
- ✅ テキスト指定をフラグからコマンド引数に変更し、より直感的なCLI操作を実現
- ✅ 不要なファイルを削除し、コード全体をリファクタリング
- ✅ コードの可読性・保守性を向上

### PomodoBar
- ✅ Electronでバー表示型ポモドーロタイマーアプリの開発を開始
- ✅ バーへの表示方法を調査・実装中

## Checklist

- [ ] I have tested my code
- [x] I have updated documentation (if applicable)
- [x] I have added the "100days" label to this PR